### PR TITLE
Bug fix: incorrect ports in multiple orderers config

### DIFF
--- a/bash/.env
+++ b/bash/.env
@@ -1,6 +1,6 @@
 COMPOSE_PROJECT_NAME=net
 # default image tag (replace both tags below if you are building newer versions from the Fabric and Fabric-CA source code)
-# Currently the latest version; replace with higher versions of the form '2.1.x' if required
+# Currently the latest version; replace with higher versions of the form '2.2.x' if required
 IMAGE_TAG=2.2.0
 # Currently the latest version; replace with higher versions of the form '1.4.x' if required
 CA_IMAGE_TAG=1.4.8

--- a/bash/multiple_orderers/configtx.yaml
+++ b/bash/multiple_orderers/configtx.yaml
@@ -114,7 +114,7 @@ Organizations:
             # for cross org gossip communication.  Note, this value is only
             # encoded in the genesis block in the Application section context
             - Host: peer0.importerorg.trade.com
-              Port: 7051
+              Port: 8051
 
     - &CarrierOrg
         # DefaultOrg defines the organization which is used in the sampleconfig
@@ -148,7 +148,7 @@ Organizations:
             # for cross org gossip communication.  Note, this value is only
             # encoded in the genesis block in the Application section context
             - Host: peer0.carrierorg.trade.com
-              Port: 7051
+              Port: 9051
 
     - &RegulatorOrg
         # DefaultOrg defines the organization which is used in the sampleconfig
@@ -182,7 +182,7 @@ Organizations:
             # for cross org gossip communication.  Note, this value is only
             # encoded in the genesis block in the Application section context
             - Host: peer0.regulatororg.trade.com
-              Port: 7051
+              Port: 10051
 
 ################################################################################
 #


### PR DESCRIPTION
Gave anchor peers unique ports so 'bash/multiple_orderers/configtx.yaml' now matches 'bash/configtx.yaml'.
Fixed a typo in a comment.