### PR TITLE
Add platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 :exclamation: Scripts have been tested and are supported on the following operating systems:  
 * Ubuntu 18.04 and 20.04  
 * mac OS Catalina (10.15)  
+  
 Unfortunately, other operating systems will be supported on a best effort basis.
 
 ## Use Case Description

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Trade Network
 
+:exclamation: Scripts have been tested and are supported on the following operating systems:  
+* Ubuntu 18.04 and 20.04  
+* mac OS Catalina (10.15)  
+Unfortunately, other operating systems will be supported on a best effort basis.
+
 ## Use Case Description
 See the [Use Case Document](USE-CASE.md) for a full description of the use case driving the Fabric network and application.
 

--- a/bash/.env
+++ b/bash/.env
@@ -5,3 +5,5 @@ IMAGE_TAG=2.2.0
 # Currently the latest version; replace with higher versions of the form '1.4.x' if required
 CA_IMAGE_TAG=1.4.8
 SYS_CHANNEL=trade-sys-channel
+PLATFORM=linux/amd64
+UNIX_SOCK=/var/run/docker.sock

--- a/bash/base/docker-compose-base.yaml
+++ b/bash/base/docker-compose-base.yaml
@@ -34,7 +34,7 @@ services:
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.exporterorg.trade.com:7051
       - CORE_PEER_LOCALMSPID=ExporterOrgMSP
     volumes:
-        - /var/run/:/host/var/run/
+        - $UNIX_SOCK:/host/var/run/docker.sock
         - ../crypto-config/peerOrganizations/exporterorg.trade.com/peers/peer0.exporterorg.trade.com/msp:/etc/hyperledger/fabric/msp
         - ../crypto-config/peerOrganizations/exporterorg.trade.com/peers/peer0.exporterorg.trade.com/tls:/etc/hyperledger/fabric/tls
         - peer0.exporterorg.trade.com:/var/hyperledger/production
@@ -56,7 +56,7 @@ services:
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.importerorg.trade.com:8051
       - CORE_PEER_LOCALMSPID=ImporterOrgMSP
     volumes:
-        - /var/run/:/host/var/run/
+        - $UNIX_SOCK:/host/var/run/docker.sock
         - ../crypto-config/peerOrganizations/importerorg.trade.com/peers/peer0.importerorg.trade.com/msp:/etc/hyperledger/fabric/msp
         - ../crypto-config/peerOrganizations/importerorg.trade.com/peers/peer0.importerorg.trade.com/tls:/etc/hyperledger/fabric/tls
         - peer0.importerorg.trade.com:/var/hyperledger/production
@@ -78,7 +78,7 @@ services:
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.carrierorg.trade.com:9051
       - CORE_PEER_LOCALMSPID=CarrierOrgMSP
     volumes:
-        - /var/run/:/host/var/run/
+        - $UNIX_SOCK:/host/var/run/docker.sock
         - ../crypto-config/peerOrganizations/carrierorg.trade.com/peers/peer0.carrierorg.trade.com/msp:/etc/hyperledger/fabric/msp
         - ../crypto-config/peerOrganizations/carrierorg.trade.com/peers/peer0.carrierorg.trade.com/tls:/etc/hyperledger/fabric/tls
         - peer0.carrierorg.trade.com:/var/hyperledger/production
@@ -100,7 +100,7 @@ services:
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.regulatororg.trade.com:10051
       - CORE_PEER_LOCALMSPID=RegulatorOrgMSP
     volumes:
-        - /var/run/:/host/var/run/
+        - $UNIX_SOCK:/host/var/run/docker.sock
         - ../crypto-config/peerOrganizations/regulatororg.trade.com/peers/peer0.regulatororg.trade.com/msp:/etc/hyperledger/fabric/msp
         - ../crypto-config/peerOrganizations/regulatororg.trade.com/peers/peer0.regulatororg.trade.com/tls:/etc/hyperledger/fabric/tls
         - peer0.regulatororg.trade.com:/var/hyperledger/production

--- a/bash/base/peer-base.yaml
+++ b/bash/base/peer-base.yaml
@@ -7,6 +7,7 @@ version: '2'
 services:
   peer-base:
     image: hyperledger/fabric-peer:$IMAGE_TAG
+    platform: $PLATFORM
     environment:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       # the following setting starts chaincode containers on the same
@@ -29,6 +30,7 @@ services:
 
   orderer-base:
     image: hyperledger/fabric-orderer:$IMAGE_TAG
+    platform: $PLATFORM
     environment:
       - FABRIC_LOGGING_SPEC=INFO
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0

--- a/bash/devmode/.env
+++ b/bash/devmode/.env
@@ -5,3 +5,5 @@ IMAGE_TAG=2.2.0
 # Currently the latest version; replace with higher versions of the form '1.4.x' if required
 CA_IMAGE_TAG=1.4.7
 SYS_CHANNEL=trade-sys-channel
+PLATFORM=linux/amd64
+UNIX_SOCK=/var/run/docker.sock

--- a/bash/devmode/docker-compose-e2e.yaml
+++ b/bash/devmode/docker-compose-e2e.yaml
@@ -8,6 +8,7 @@ services:
   orderer:
     container_name: orderer
     image: hyperledger/fabric-orderer:$IMAGE_TAG
+    platform: $PLATFORM
     environment:
       - FABRIC_LOGGING_SPEC=debug
       - ORDERER_GENERAL_LISTENADDRESS=orderer
@@ -28,6 +29,7 @@ services:
   peer:
     container_name: peer
     image: hyperledger/fabric-peer:$IMAGE_TAG
+    platform: $PLATFORM
     environment:
       - CORE_PEER_ID=peer0.devorg.trade.com
       - CORE_PEER_ADDRESS=peer:7051
@@ -41,7 +43,7 @@ services:
       - FABRIC_LOGGING_SPEC=DEBUG
       - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp
     volumes:
-        - /var/run/:/host/var/run/
+        - $UNIX_SOCK:/host/var/run/docker.sock
         - ./crypto-config/peerOrganizations/devorg.trade.com/peers/peer0.devorg.trade.com/msp:/etc/hyperledger/msp
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric/peer
     command: peer node start --peer-chaincodedev
@@ -53,6 +55,7 @@ services:
   ca:
     container_name: ca
     image: hyperledger/fabric-ca:$CA_IMAGE_TAG
+    platform: $PLATFORM
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca
@@ -66,6 +69,7 @@ services:
   cli:
     container_name: cli
     image: hyperledger/fabric-tools:$IMAGE_TAG
+    platform: $PLATFORM
     tty: true
     environment:
       - SYS_CHANNEL=$SYS_CHANNEL
@@ -79,7 +83,7 @@ services:
     working_dir: /opt/gopath/src/chaincodedev
     command: /bin/bash -c '/opt/trade/setupChannel.sh'
     volumes:
-        - /var/run/:/host/var/run/
+        - $UNIX_SOCK:/host/var/run/docker.sock
         - ./crypto-config/peerOrganizations/devorg.trade.com/users/Admin@devorg.trade.com/msp:/etc/hyperledger/msp
         - ./channel-artifacts:/opt/trade/channel-artifacts
         - ./../../chaincode:/opt/gopath/src/chaincodedev/chaincode
@@ -91,6 +95,7 @@ services:
   chaincode-java:
     container_name: chaincode-java
     image: hyperledger/fabric-javaenv:$IMAGE_TAG
+    platform: $PLATFORM
     tty: true
     environment:
       - GOPATH=/opt/gopath
@@ -102,7 +107,7 @@ services:
       - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp
     working_dir: /opt/gopath/src/chaincode
     volumes:
-        - /var/run/:/host/var/run/
+        - $UNIX_SOCK:/host/var/run/docker.sock
         - ./crypto-config/peerOrganizations/devorg.trade.com/peers/peer0.devorg.trade.com/msp:/etc/hyperledger/msp
         - ./../../contracts/v1/letterOfCredit:/opt/gopath/src/chaincode/letterOfCredit
     depends_on:
@@ -112,6 +117,7 @@ services:
   chaincode-node:
     container_name: chaincode-node
     image: hyperledger/fabric-nodeenv:$IMAGE_TAG
+    platform: $PLATFORM
     tty: true
     environment:
       - GOPATH=/opt/gopath
@@ -123,7 +129,7 @@ services:
       - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp
     working_dir: /opt/gopath/src/chaincode
     volumes:
-        - /var/run/:/host/var/run/
+        - $UNIX_SOCK:/host/var/run/docker.sock
         - ./crypto-config/peerOrganizations/devorg.trade.com/peers/peer0.devorg.trade.com/msp:/etc/hyperledger/msp
         - ./../../contracts/v1/trade:/opt/gopath/src/chaincode/trade
     depends_on:

--- a/bash/docker-compose-another-importer-peer.yaml
+++ b/bash/docker-compose-another-importer-peer.yaml
@@ -14,6 +14,7 @@ services:
   couchdb-peer1.importerorg.trade.com:
     container_name: couchdb-peer1.importerorg.trade.com
     image: couchdb:2.3
+    platform: $PLATFORM
     # Populate the COUCHDB_USER and COUCHDB_PASSWORD to set an admin user and password
     # for CouchDB.  This will prevent CouchDB from operating in an "Admin Party" mode.
     environment:

--- a/bash/docker-compose-cli.yaml
+++ b/bash/docker-compose-cli.yaml
@@ -13,6 +13,7 @@ services:
   cli:
     container_name: trade_cli
     image: hyperledger/fabric-tools:$IMAGE_TAG
+    platform: $PLATFORM
     #tty: true
     stdin_open: true
     environment:

--- a/bash/docker-compose-couchdb.yaml
+++ b/bash/docker-compose-couchdb.yaml
@@ -11,6 +11,7 @@ services:
   couchdb-peer0.exporterorg.trade.com:
     container_name: couchdb-peer0.exporterorg.trade.com
     image: couchdb:2.3
+    platform: $PLATFORM
     # Populate the COUCHDB_USER and COUCHDB_PASSWORD to set an admin user and password
     # for CouchDB.  This will prevent CouchDB from operating in an "Admin Party" mode.
     environment:
@@ -38,6 +39,7 @@ services:
   couchdb-peer0.importerorg.trade.com:
     container_name: couchdb-peer0.importerorg.trade.com
     image: couchdb:2.3
+    platform: $PLATFORM
     # Populate the COUCHDB_USER and COUCHDB_PASSWORD to set an admin user and password
     # for CouchDB.  This will prevent CouchDB from operating in an "Admin Party" mode.
     environment:
@@ -65,6 +67,7 @@ services:
   couchdb-peer0.regulatororg.trade.com:
     container_name: couchdb-peer0.regulatororg.trade.com
     image: couchdb:2.3
+    platform: $PLATFORM
     # Populate the COUCHDB_USER and COUCHDB_PASSWORD to set an admin user and password
     # for CouchDB.  This will prevent CouchDB from operating in an "Admin Party" mode.
     environment:

--- a/bash/docker-compose-e2e.yaml
+++ b/bash/docker-compose-e2e.yaml
@@ -20,6 +20,7 @@ networks:
 services:
   exporter-ca:
     image: hyperledger/fabric-ca:$CA_IMAGE_TAG
+    platform: $PLATFORM
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-exporterorg
@@ -38,6 +39,7 @@ services:
 
   importer-ca:
     image: hyperledger/fabric-ca:$CA_IMAGE_TAG
+    platform: $PLATFORM
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-importerorg
@@ -56,6 +58,7 @@ services:
 
   carrier-ca:
     image: hyperledger/fabric-ca:$CA_IMAGE_TAG
+    platform: $PLATFORM
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-carrierorg
@@ -74,6 +77,7 @@ services:
 
   regulator-ca:
     image: hyperledger/fabric-ca:$CA_IMAGE_TAG
+    platform: $PLATFORM
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-regulatororg

--- a/bash/docker-compose-exportingEntityOrg.yaml
+++ b/bash/docker-compose-exportingEntityOrg.yaml
@@ -14,6 +14,7 @@ networks:
 services:
   exportingentity-ca:
     image: hyperledger/fabric-ca:$CA_IMAGE_TAG
+    platform: $PLATFORM
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-exportingentityorg
@@ -33,6 +34,7 @@ services:
   couchdb-peer0.exportingentityorg.trade.com:
     container_name: couchdb-peer0.exportingentityorg.trade.com
     image: couchdb:2.3
+    platform: $PLATFORM
     # Populate the COUCHDB_USER and COUCHDB_PASSWORD to set an admin user and password
     # for CouchDB.  This will prevent CouchDB from operating in an "Admin Party" mode.
     environment:

--- a/bash/trade.sh
+++ b/bash/trade.sh
@@ -184,7 +184,7 @@ function checkPrereqs() {
   # Note, we check configtxlator externally because it does not require a config file, and peer in the
   # docker image because of FAB-8551 that makes configtxlator return 'development version' in docker
   LOCAL_VERSION=$(configtxlator version | sed -ne 's/ Version: //p')
-  DOCKER_IMAGE_VERSION=$(docker run --rm hyperledger/fabric-tools:$IMAGE_TAG peer version | sed -ne 's/ Version: //p'|head -1)
+  DOCKER_IMAGE_VERSION=$(docker run --platform $PLATFORM --rm hyperledger/fabric-tools:$IMAGE_TAG peer version | sed -ne 's/ Version: //p'|head -1)
 
   echo "LOCAL_VERSION=$LOCAL_VERSION"
   echo "DOCKER_IMAGE_VERSION=$DOCKER_IMAGE_VERSION"

--- a/bash/utils/generateAllProfiles.sh
+++ b/bash/utils/generateAllProfiles.sh
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+mkdir -p ../../gateways
 node manage-connection-profile.js --generate exporterorg ExporterOrgMSP 7051 7054
 node manage-connection-profile.js --generate importerorg ImporterOrgMSP 8051 8054
 node manage-connection-profile.js --generate carrierorg CarrierOrgMSP 9051 9054

--- a/legacy_sdk_1.4/package.json
+++ b/legacy_sdk_1.4/package.json
@@ -8,7 +8,6 @@
     "fabric-client": "~1.4.0",
     "fabric-network": "~1.4.0",
     "fs-extra": "^2.0.0",
-    "jsrsasign": "6.2.2",
     "tape": "^4.5.1",
     "tape-promise": "^1.1.0"
   },


### PR DESCRIPTION
Contains three major changes:
1. Update to README OS support statement
2. Fix to the generateConnectionProfile which was failing when the gateways folder did not exist
3. Added the PLATFORM and UNIX_SOCK to the docker-compose to ensure the network works with Mac M1 and address a recent docker issue with unix socket.