### PR TITLE
Fixing bash trade.sh script to enable 'reset' option

### DIFF
--- a/bash/trade.sh
+++ b/bash/trade.sh
@@ -1355,6 +1355,8 @@ elif [ "$MODE" == "down" ]; then
   EXPMODE="Stopping network"
 elif [ "$MODE" == "restart" ]; then
   EXPMODE="Restarting network"
+elif [ "$MODE" == "reset" ]; then
+  EXPMODE="Cleaning temporary user credentials and chaincode containers"
 elif [ "$MODE" == "clean" ]; then
   EXPMODE="Cleaning network and channel configurations"
 elif [ "$MODE" == "cleanall" ]; then


### PR DESCRIPTION
The script missed a condition check for the 'reset' option earlier, resulting in the CLI help getting printed on the terminal.

Signed-off-by: VRamakrishna <vramakr2@in.ibm.com>

Closes #12 